### PR TITLE
(DRAFT): feat: add --branch and --tag filtering for GitLab and GitHub

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -68,6 +68,20 @@ enum Commands {
             help = "Minimum execution percentage to include a job (e.g., 0.2 means jobs must have at least 0.2% of total executions)"
         )]
         min_executions_percentage: f64,
+
+        #[arg(
+            long,
+            conflicts_with = "tag",
+            help = "Filter jobs by branch name (e.g., 'main', 'develop')"
+        )]
+        branch: Option<String>,
+
+        #[arg(
+            long,
+            conflicts_with = "branch",
+            help = "Filter jobs by tag name (e.g., 'v1.0.0')"
+        )]
+        tag: Option<String>,
     },
     /// Collect CI/CD insights from GitHub Actions
     Github {
@@ -96,6 +110,20 @@ enum Commands {
             help = "Minimum execution percentage to include a job (e.g., 0.2 means jobs must have at least 0.2% of total executions)"
         )]
         min_executions_percentage: f64,
+
+        #[arg(
+            long,
+            conflicts_with = "tag",
+            help = "Filter jobs by branch name (e.g., 'main', 'develop')"
+        )]
+        branch: Option<String>,
+
+        #[arg(
+            long,
+            conflicts_with = "branch",
+            help = "Filter jobs by tag name (e.g., 'v1.0.0')"
+        )]
+        tag: Option<String>,
     },
 }
 
@@ -109,6 +137,8 @@ impl Cli {
         limit: usize,
         clear_cache: bool,
         min_executions_percentage: f64,
+        branch: Option<&String>,
+        tag: Option<&String>,
     ) -> Result<()> {
         if clear_cache {
             crate::providers::gitlab::JobCache::clear(project_path)?;
@@ -128,7 +158,12 @@ impl Cli {
 
         info!("Collecting GitLab insights for project: {project_path}");
         let insights = provider
-            .collect_insights(limit, min_executions_percentage)
+            .collect_insights(
+                limit,
+                min_executions_percentage,
+                branch.map(String::as_str),
+                tag.map(String::as_str),
+            )
             .await?;
 
         if self.json_pretty {
@@ -153,6 +188,8 @@ impl Cli {
         limit: usize,
         clear_cache: bool,
         min_executions_percentage: f64,
+        branch: Option<&String>,
+        tag: Option<&String>,
     ) -> Result<()> {
         if clear_cache {
             crate::providers::github::JobCache::clear(repository)?;
@@ -172,7 +209,12 @@ impl Cli {
 
         info!("Collecting GitHub Actions insights for repository: {repository}");
         let insights = provider
-            .collect_insights(limit, min_executions_percentage)
+            .collect_insights(
+                limit,
+                min_executions_percentage,
+                branch.map(String::as_str),
+                tag.map(String::as_str),
+            )
             .await?;
 
         if self.json_pretty {
@@ -198,6 +240,8 @@ impl Cli {
                 limit,
                 clear_cache,
                 min_executions_percentage,
+                branch,
+                tag,
             } => {
                 self.execute_gitlab(
                     project_path,
@@ -206,6 +250,8 @@ impl Cli {
                     *limit,
                     *clear_cache,
                     *min_executions_percentage,
+                    branch.as_ref(),
+                    tag.as_ref(),
                 )
                 .await
             }
@@ -216,6 +262,8 @@ impl Cli {
                 limit,
                 clear_cache,
                 min_executions_percentage,
+                branch,
+                tag,
             } => {
                 self.execute_github(
                     repository,
@@ -224,6 +272,8 @@ impl Cli {
                     *limit,
                     *clear_cache,
                     *min_executions_percentage,
+                    branch.as_ref(),
+                    tag.as_ref(),
                 )
                 .await
             }

--- a/src/providers/github/client/jobs.rs
+++ b/src/providers/github/client/jobs.rs
@@ -50,6 +50,7 @@ impl GitHubClient {
     /// # Arguments
     ///
     /// * `page` - Page number to fetch (1-indexed)
+    /// * `branch` - Optional branch or tag name to filter runs by
     ///
     /// # Returns
     ///
@@ -58,11 +59,15 @@ impl GitHubClient {
     /// # Errors
     ///
     /// Returns an error if the API request fails or response cannot be parsed
-    pub async fn fetch_runs(&self, page: usize) -> Result<Vec<WorkflowRun>> {
-        let path = format!(
+    pub async fn fetch_runs(&self, page: usize, branch: Option<&str>) -> Result<Vec<WorkflowRun>> {
+        let mut path = format!(
             "repos/{}/{}/actions/runs?per_page={}&page={}",
             self.owner, self.repo, PAGE_SIZE, page
         );
+
+        if let Some(branch_name) = branch {
+            path.push_str(&format!("&branch={branch_name}"));
+        }
 
         let url = self
             .api_url
@@ -159,6 +164,40 @@ mod tests {
         assert_eq!(
             expected_path,
             "repos/test-owner/test-repo/actions/runs?per_page=100&page=5"
+        );
+    }
+
+    #[test]
+    fn test_fetch_runs_url_construction_with_branch_filter() {
+        let owner = "test-owner";
+        let repo = "test-repo";
+        let page = 1;
+        let branch = "main";
+
+        let expected_path = format!(
+            "repos/{owner}/{repo}/actions/runs?per_page={PAGE_SIZE}&page={page}&branch={branch}"
+        );
+
+        assert_eq!(
+            expected_path,
+            "repos/test-owner/test-repo/actions/runs?per_page=100&page=1&branch=main"
+        );
+    }
+
+    #[test]
+    fn test_fetch_runs_url_construction_with_tag_filter() {
+        let owner = "test-owner";
+        let repo = "test-repo";
+        let page = 2;
+        let tag = "v1.0.0";
+
+        let expected_path = format!(
+            "repos/{owner}/{repo}/actions/runs?per_page={PAGE_SIZE}&page={page}&branch={tag}"
+        );
+
+        assert_eq!(
+            expected_path,
+            "repos/test-owner/test-repo/actions/runs?per_page=100&page=2&branch=v1.0.0"
         );
     }
 

--- a/src/providers/github/provider.rs
+++ b/src/providers/github/provider.rs
@@ -75,11 +75,14 @@ impl GitHubProvider {
     /// - If cache exists and has enough jobs, uses cached data
     /// - If cache exists but doesn't have enough jobs, merges cached with fresh jobs
     /// - Otherwise fetches from API and saves to cache
+    /// - Cache is bypassed when `branch` or `tag` filter is specified
     ///
     /// # Arguments
     ///
     /// * `limit` - Maximum number of jobs to fetch
     /// * `min_executions_percentage` - Minimum percentage of total executions for a job to be included
+    /// * `branch` - Optional branch name to filter runs by (e.g., "main")
+    /// * `tag` - Optional tag name to filter runs by (e.g., "v1.0.0")
     ///
     /// # Returns
     ///
@@ -95,6 +98,8 @@ impl GitHubProvider {
         &self,
         limit: usize,
         min_executions_percentage: f64,
+        branch: Option<&str>,
+        tag: Option<&str>,
     ) -> Result<CIInsights> {
         info!(
             "Starting insights collection for repository: {}",
@@ -104,7 +109,14 @@ impl GitHubProvider {
         // Phase 1: Check cache or fetch jobs
         let progress = PhaseProgress::start_phase_1();
 
-        let jobs = if let Some(cache) = JobCache::load(&self.repository) {
+        // GitHub uses the same `branch` API parameter for both branch and tag filtering
+        // (the API matches on `head_branch` which contains the tag name for tag-triggered runs)
+        let ref_filter = branch.or(tag);
+
+        let jobs = if let Some(ref_name) = ref_filter {
+            info!("Ref filter active: '{ref_name}' - fetching from API (cache bypassed)");
+            self.fetch_jobs_from_api(limit, Some(ref_name)).await?
+        } else if let Some(cache) = JobCache::load(&self.repository) {
             if cache.jobs.len() >= limit {
                 info!("Using {} cached jobs (limit: {})", cache.jobs.len(), limit);
                 Self::map_to_sorted_jobs(cache.jobs, limit)
@@ -115,7 +127,8 @@ impl GitHubProvider {
                     cache.jobs.len(),
                     limit
                 );
-                self.fetch_and_merge_until_limit(cache.jobs, limit).await?
+                self.fetch_and_merge_until_limit(cache.jobs, limit, None)
+                    .await?
             }
         } else {
             info!("No cache found, fetching from API");
@@ -142,7 +155,7 @@ impl GitHubProvider {
 
     /// Fetches jobs from API and saves to cache.
     async fn fetch_and_cache_jobs(&self, limit: usize) -> Result<Vec<GitHubJob>> {
-        let jobs = self.fetch_jobs_from_api(limit).await?;
+        let jobs = self.fetch_jobs_from_api(limit, None).await?;
         self.save_cache(&jobs);
         Ok(jobs)
     }
@@ -152,7 +165,11 @@ impl GitHubProvider {
     /// Orchestrates fetching workflow runs and their jobs from the GitHub API.
     /// Fetches runs page-by-page, processing each page's jobs concurrently.
     /// Stops when the job limit is reached to avoid over-fetching runs.
-    async fn fetch_jobs_from_api(&self, limit: usize) -> Result<Vec<GitHubJob>> {
+    async fn fetch_jobs_from_api(
+        &self,
+        limit: usize,
+        branch: Option<&str>,
+    ) -> Result<Vec<GitHubJob>> {
         info!("Fetching GitHub Actions jobs (limit: {limit})...");
 
         let mut all_jobs = Vec::new();
@@ -165,7 +182,7 @@ impl GitHubProvider {
                 all_jobs.len()
             );
 
-            let runs = self.client.fetch_runs(page).await?;
+            let runs = self.client.fetch_runs(page, branch).await?;
 
             if runs.is_empty() {
                 info!("No more workflow runs found");
@@ -231,6 +248,7 @@ impl GitHubProvider {
         &self,
         mut cached_jobs: std::collections::HashMap<u64, GitHubJob>,
         limit: usize,
+        branch: Option<&str>,
     ) -> Result<Vec<GitHubJob>> {
         let mut page = 1;
         let initial_cache_size = cached_jobs.len();
@@ -252,7 +270,7 @@ impl GitHubProvider {
             info!("Have {unique_count} unique jobs, need {limit} - fetching more (page {page})...");
 
             // Fetch next page of runs
-            let runs = self.client.fetch_runs(page).await?;
+            let runs = self.client.fetch_runs(page, branch).await?;
 
             if runs.is_empty() {
                 info!("No more workflow runs available. Collected {unique_count} unique jobs (requested {limit})");

--- a/src/providers/gitlab/client/jobs.rs
+++ b/src/providers/gitlab/client/jobs.rs
@@ -1,8 +1,14 @@
 use chrono::{DateTime as ChronoDateTime, Utc};
 use graphql_client::GraphQLQuery;
+use log::info;
 
 use super::core::{GitLabClient, PAGE_SIZE};
+
+/// Number of pipelines to fetch per page when filtering by branch/tag.
+/// Kept small to limit response payload size — each pipeline carries up to 100 jobs.
+const PIPELINE_PAGE_SIZE: i64 = 20;
 use crate::error::{CILensError, Result};
+use crate::providers::gitlab::types::GitLabJob;
 
 pub type JobID = String;
 pub type Time = ChronoDateTime<Utc>;
@@ -16,6 +22,17 @@ pub type Time = ChronoDateTime<Utc>;
 pub struct FetchJobs;
 
 pub use fetch_jobs::*;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/providers/gitlab/client/schema.json",
+    query_path = "src/providers/gitlab/client/jobs_by_ref.graphql",
+    response_derives = "Debug",
+    variables_derives = "Clone"
+)]
+pub struct FetchJobsByRef;
+
+pub use fetch_jobs_by_ref::RefType as GitLabRefType;
 
 impl GitLabClient {
     /// Fetches all jobs for a project with SUCCESS or FAILED status.
@@ -72,5 +89,136 @@ impl GitLabClient {
         }
 
         Ok(all_jobs)
+    }
+
+    /// Fetches jobs for a project filtered by branch or tag ref.
+    ///
+    /// Queries pipelines filtered by `git_ref` and `ref_type`, then collects all
+    /// SUCCESS/FAILED jobs from those pipelines. Paginates through pipeline pages.
+    ///
+    /// # Arguments
+    ///
+    /// * `project_path` - Full path to the GitLab project (e.g., "group/project")
+    /// * `git_ref` - Branch or tag name to filter by (e.g., "main", "v1.0.0")
+    /// * `ref_type` - Whether `git_ref` is a branch (`Heads`) or tag (`Tags`)
+    /// * `limit` - Maximum number of jobs to collect
+    ///
+    /// # Returns
+    ///
+    /// Vector of `GitLabJob` structs collected from matching pipelines.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the project is not found or the API request fails.
+    /// Fetches jobs for a project filtered by branch or tag ref.
+    ///
+    /// Queries pipelines filtered by `git_ref` and optionally `ref_type`, then collects all
+    /// SUCCESS/FAILED jobs from those pipelines. Paginates through pipeline pages.
+    ///
+    /// `ref_type` should be:
+    /// - `None` for branch filtering (includes both push and MR pipelines for the branch)
+    /// - `Some(RefType::TAGS)` for tag filtering
+    ///
+    /// # Arguments
+    ///
+    /// * `project_path` - Full path to the GitLab project (e.g., "group/project")
+    /// * `git_ref` - Branch or tag name to filter by (e.g., "main", "v1.0.0")
+    /// * `ref_type` - Optional ref type (`None` = any, `Some(TAGS)` = tags only)
+    /// * `limit` - Maximum number of jobs to collect
+    pub async fn fetch_jobs_by_ref(
+        &self,
+        project_path: &str,
+        git_ref: &str,
+        ref_type: Option<fetch_jobs_by_ref::RefType>,
+        limit: usize,
+    ) -> Result<Vec<GitLabJob>> {
+        let mut all_jobs: Vec<GitLabJob> = Vec::new();
+        let mut cursor: Option<String> = None;
+
+        while all_jobs.len() < limit {
+            #[allow(clippy::cast_possible_wrap)]
+            let variables = fetch_jobs_by_ref::Variables {
+                project_path: project_path.to_string(),
+                git_ref: git_ref.to_string(),
+                ref_type: ref_type.clone(),
+                first_pipelines: PIPELINE_PAGE_SIZE,
+                after_pipeline: cursor.clone(),
+            };
+
+            let request_body = FetchJobsByRef::build_query(variables);
+
+            let data: fetch_jobs_by_ref::ResponseData =
+                self.execute_graphql_request(&request_body).await?;
+
+            let project = data
+                .project
+                .ok_or_else(|| CILensError::ProjectNotFound(project_path.to_string()))?;
+
+            let pipelines = project
+                .pipelines
+                .ok_or_else(|| CILensError::NoJobData(project_path.to_string()))?;
+
+            let page_info = pipelines.page_info;
+
+            for pipeline_node in pipelines.nodes.into_iter().flatten().flatten() {
+                if let Some(jobs_conn) = pipeline_node.jobs {
+                    for job_node in jobs_conn.nodes.into_iter().flatten().flatten() {
+                        if let Some(gitlab_job) = Self::transform_pipeline_job(job_node) {
+                            all_jobs.push(gitlab_job);
+                        }
+                    }
+                }
+            }
+
+            info!(
+                "Collected {} jobs from pipelines for ref '{}'",
+                all_jobs.len(),
+                git_ref
+            );
+
+            if !page_info.has_next_page {
+                break;
+            }
+
+            cursor = page_info.end_cursor;
+        }
+
+        all_jobs.truncate(limit);
+        Ok(all_jobs)
+    }
+
+    /// Transforms a raw pipeline job node into a `GitLabJob`.
+    ///
+    /// Returns `None` if required fields (id, name, finished_at) are missing.
+    fn transform_pipeline_job(
+        node: fetch_jobs_by_ref::FetchJobsByRefProjectPipelinesNodesJobsNodes,
+    ) -> Option<GitLabJob> {
+        let id = node.id?;
+        let name = node.name?;
+        let finished_at = node.finished_at?;
+
+        #[allow(clippy::cast_precision_loss, clippy::cast_sign_loss)]
+        Some(GitLabJob {
+            id,
+            name,
+            duration: node.duration.unwrap_or(0) as f64,
+            status: node
+                .status
+                .map_or_else(|| "UNKNOWN".to_string(), |s| format!("{s:?}")),
+            retried: node.retried.unwrap_or(false),
+            needs: node
+                .needs
+                .map(|conn| {
+                    conn.nodes
+                        .into_iter()
+                        .flatten()
+                        .flatten()
+                        .filter_map(|n| n.name)
+                        .collect()
+                })
+                .unwrap_or_default(),
+            created_at: node.created_at,
+            finished_at,
+        })
     }
 }

--- a/src/providers/gitlab/client/jobs_by_ref.graphql
+++ b/src/providers/gitlab/client/jobs_by_ref.graphql
@@ -1,0 +1,28 @@
+query FetchJobsByRef($projectPath: ID!, $gitRef: String!, $refType: RefType, $firstPipelines: Int!, $afterPipeline: String) {
+  project(fullPath: $projectPath) {
+    pipelines(ref: $gitRef, refType: $refType, first: $firstPipelines, after: $afterPipeline) {
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+      nodes {
+        jobs(statuses: [SUCCESS, FAILED], first: 100) {
+          nodes {
+            id
+            name
+            status
+            duration
+            createdAt
+            finishedAt
+            retried
+            needs {
+              nodes {
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/providers/gitlab/provider.rs
+++ b/src/providers/gitlab/provider.rs
@@ -118,11 +118,14 @@ impl GitLabProvider {
     /// - If cache exists and has enough jobs, uses cached data
     /// - If cache exists but doesn't have enough jobs, merges cached with fresh jobs
     /// - Otherwise fetches from API and saves to cache
+    /// - Cache is bypassed when `branch` or `tag` filter is specified
     ///
     /// # Arguments
     ///
     /// * `limit` - Maximum number of jobs to fetch
     /// * `min_executions_percentage` - Minimum percentage of total executions for a job to be included
+    /// * `branch` - Optional branch name to filter jobs by (e.g., "main")
+    /// * `tag` - Optional tag name to filter jobs by (e.g., "v1.0.0")
     ///
     /// # Returns
     ///
@@ -138,6 +141,8 @@ impl GitLabProvider {
         &self,
         limit: usize,
         min_executions_percentage: f64,
+        branch: Option<&str>,
+        tag: Option<&str>,
     ) -> Result<CIInsights> {
         info!(
             "Starting insights collection for project: {}",
@@ -147,7 +152,13 @@ impl GitLabProvider {
         // Phase 1: Check cache or fetch jobs
         let progress = PhaseProgress::start_phase_1();
 
-        let jobs = if let Some(cache) = JobCache::load(&self.project_path) {
+        let jobs = if let Some(branch_name) = branch {
+            info!("Branch filter active: '{branch_name}' - fetching from API (cache bypassed)");
+            self.fetch_jobs_by_branch(branch_name, limit).await?
+        } else if let Some(tag_name) = tag {
+            info!("Tag filter active: '{tag_name}' - fetching from API (cache bypassed)");
+            self.fetch_jobs_by_tag(tag_name, limit).await?
+        } else if let Some(cache) = JobCache::load(&self.project_path) {
             if cache.jobs.len() >= limit {
                 info!("Using {} cached jobs (limit: {})", cache.jobs.len(), limit);
                 Self::map_to_sorted_jobs(cache.jobs, limit)
@@ -200,6 +211,30 @@ impl GitLabProvider {
         let job_nodes = self.client.fetch_jobs(&self.project_path, limit).await?;
         info!("Fetched {} jobs from API", job_nodes.len());
         Ok(Self::transform_job_nodes(job_nodes))
+    }
+
+    /// Fetches jobs filtered by branch name (bypasses cache).
+    ///
+    /// Does NOT pass `refType` so GitLab returns all pipeline types for the branch
+    /// (push pipelines AND merge request pipelines).
+    async fn fetch_jobs_by_branch(&self, branch: &str, limit: usize) -> Result<Vec<GitLabJob>> {
+        let jobs = self
+            .client
+            .fetch_jobs_by_ref(&self.project_path, branch, None, limit)
+            .await?;
+        info!("Fetched {} jobs for branch '{}'", jobs.len(), branch);
+        Ok(jobs)
+    }
+
+    /// Fetches jobs filtered by tag name (bypasses cache).
+    async fn fetch_jobs_by_tag(&self, tag: &str, limit: usize) -> Result<Vec<GitLabJob>> {
+        use super::client::jobs::GitLabRefType;
+        let jobs = self
+            .client
+            .fetch_jobs_by_ref(&self.project_path, tag, Some(GitLabRefType::TAGS), limit)
+            .await?;
+        info!("Fetched {} jobs for tag '{}'", jobs.len(), tag);
+        Ok(jobs)
     }
 
     /// Fetches jobs and merges with cache until we have enough unique jobs.
@@ -258,5 +293,75 @@ impl GitLabProvider {
         let result = Self::map_to_sorted_jobs(cached_jobs, limit);
         self.save_cache(&result);
         Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{TimeZone, Utc};
+
+    fn make_job(id: &str, created_at: chrono::DateTime<Utc>) -> GitLabJob {
+        GitLabJob {
+            id: id.to_string(),
+            name: "test-job".to_string(),
+            duration: 60.0,
+            status: "SUCCESS".to_string(),
+            retried: false,
+            needs: vec![],
+            created_at,
+            finished_at: created_at + chrono::Duration::seconds(60),
+        }
+    }
+
+    #[test]
+    fn test_jobs_to_map() {
+        let jobs = vec![
+            make_job("id1", Utc.timestamp_opt(1_000, 0).unwrap()),
+            make_job("id2", Utc.timestamp_opt(2_000, 0).unwrap()),
+        ];
+        let map = GitLabProvider::jobs_to_map(&jobs);
+        assert_eq!(map.len(), 2);
+        assert!(map.contains_key("id1"));
+        assert!(map.contains_key("id2"));
+    }
+
+    #[test]
+    fn test_map_to_sorted_jobs_order() {
+        let mut map = std::collections::HashMap::new();
+        map.insert(
+            "older".to_string(),
+            make_job("older", Utc.timestamp_opt(1_000, 0).unwrap()),
+        );
+        map.insert(
+            "newer".to_string(),
+            make_job("newer", Utc.timestamp_opt(9_000, 0).unwrap()),
+        );
+        map.insert(
+            "middle".to_string(),
+            make_job("middle", Utc.timestamp_opt(5_000, 0).unwrap()),
+        );
+
+        let sorted = GitLabProvider::map_to_sorted_jobs(map, 10);
+
+        assert_eq!(sorted.len(), 3);
+        assert_eq!(sorted[0].id, "newer");
+        assert_eq!(sorted[1].id, "middle");
+        assert_eq!(sorted[2].id, "older");
+    }
+
+    #[test]
+    fn test_map_to_sorted_jobs_respects_limit() {
+        let mut map = std::collections::HashMap::new();
+        for i in 0..10u64 {
+            let id = format!("job-{i}");
+            map.insert(
+                id.clone(),
+                make_job(&id, Utc.timestamp_opt(i as i64 * 1000, 0).unwrap()),
+            );
+        }
+
+        let sorted = GitLabProvider::map_to_sorted_jobs(map, 3);
+        assert_eq!(sorted.len(), 3);
     }
 }


### PR DESCRIPTION
Ongoing MR: local tests/review still needed on my side

Adds two new flags to both the `gitlab` and `github` subcommands:
  --branch <NAME>   filter jobs by branch name (e.g. 'main', 'develop')
  --tag <NAME>      filter jobs by tag name (e.g. 'v1.0.0')

The two flags are mutually exclusive. When either is set, the job cache is bypassed so filtered results never pollute the general cache.

GitLab:
- Adds a new GraphQL query (jobs_by_ref.graphql) that queries project.pipelines(ref, refType) and collects nested pipeline jobs. refType is omitted for branches so MR pipelines (stored as refs/merge-requests/*/head) are included alongside push pipelines. refType: TAGS is used for tag filtering.
- Pipelines are fetched 20 at a time (PIPELINE_PAGE_SIZE) to keep individual response payloads small. The loop exits as soon as the accumulated job count reaches --limit, then truncates to exactly --limit before returning.

GitHub:
- Appends &branch=<name> to the workflow runs API call. GitHub's head_branch field contains the tag name for tag-triggered runs so the same parameter works for both branches and tags.