### PR TITLE
feat: migrate test suite to fixtura

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ target
 # Direnv
 .direnv
 
+# macOS metadata
+.DS_Store
+
 # Test/debug output files
 out.json
 err.log

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,6 +180,8 @@ dependencies = [
  "console",
  "dirs",
  "env_logger",
+ "fake",
+ "fixtura",
  "futures",
  "graphql_client",
  "indexmap",
@@ -280,6 +293,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,6 +323,46 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "deunicode"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
 name = "dirs"
@@ -342,6 +404,24 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "dummy"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d2a69babd8861dbe09217678b4e8ee461869f9af8a57021e16479628dbd83bd"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encode_unicode"
@@ -389,6 +469,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "fake"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6be833b323a56361118a747470a45a1bcd5c52a2ec9b1e40c83dafe687e453"
+dependencies = [
+ "chrono",
+ "deunicode",
+ "dummy",
+ "either",
+ "rand 0.10.1",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,10 +494,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
+name = "fixtura"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9acff3ae499f27cdadfb2dd2c87382dcfa2746696c9374f6d1feef83c9faf3c"
+dependencies = [
+ "fixtura-macros",
+]
+
+[[package]]
+name = "fixtura-macros"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b181017fa827913e25b87e58025293df2cc1c04d1c9c9ab3cb145ce1f2999c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -526,9 +645,23 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -606,6 +739,15 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
 ]
 
 [[package]]
@@ -841,6 +983,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -868,7 +1022,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
  "serde",
  "serde_core",
 ]
@@ -953,6 +1107,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1043,7 +1203,7 @@ dependencies = [
  "hyper-util",
  "log",
  "pin-project-lite",
- "rand",
+ "rand 0.9.2",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -1159,6 +1319,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1196,7 +1366,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1238,13 +1408,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1254,7 +1441,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1265,6 +1452,12 @@ checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redox_syscall"
@@ -1438,6 +1631,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1815,6 +2014,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1865,7 +2070,16 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.46.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -1924,6 +2138,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -2272,6 +2520,94 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.111",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,8 @@ url = "2.5"
 [dev-dependencies]
 mockito = "1.5"
 tempfile = "3.13"
+fixtura = "0.8.3"
+fake = { version = "5", features = ["derive", "chrono"] }
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/src/providers/github/cache.rs
+++ b/src/providers/github/cache.rs
@@ -155,60 +155,40 @@ impl JobCache {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::Utc;
     use std::collections::HashMap;
     use tempfile::TempDir;
 
-    fn create_test_job(id: u64, name: &str) -> GitHubJob {
-        GitHubJob {
-            id,
-            run_id: 1,
-            name: name.to_string(),
-            workflow_name: "test-workflow".to_string(),
-            status: "completed".to_string(),
-            conclusion: Some("success".to_string()),
-            run_attempt: 1,
-            duration: 60.0,
-            started_at: Utc::now(),
-            completed_at: Some(Utc::now()),
-            workflow_run_started_at: Utc::now(),
-            html_url: format!("https://github.com/owner/repo/actions/runs/1/jobs/{id}"),
-        }
-    }
-
-    #[test]
-    fn test_cache_new() {
+    #[fixtura::test]
+    fn test_cache_new(#[fixtura(id = 1u64, name = "build".to_string())] job: GitHubJob) {
         let mut jobs = HashMap::new();
-        jobs.insert(1, create_test_job(1, "build"));
-
+        jobs.insert(job.id, job);
         let cache = JobCache::new(jobs);
         assert_eq!(cache.jobs.len(), 1);
         assert_eq!(cache.jobs.get(&1).unwrap().name, "build");
     }
 
-    #[test]
-    fn test_cache_save_and_load_roundtrip() {
+    #[fixtura::test]
+    fn test_cache_save_and_load_roundtrip(
+        #[fixtura(id = 1u64, name = "build".to_string())] job1: GitHubJob,
+        #[fixtura(id = 2u64, name = "test".to_string())] job2: GitHubJob,
+        #[fixtura(id = 3u64, name = "deploy".to_string())] job3: GitHubJob,
+    ) {
         let temp_dir = TempDir::new().unwrap();
         let base_dir = temp_dir.path().to_path_buf();
 
-        let mut jobs = HashMap::new();
-        jobs.insert(1, create_test_job(1, "build"));
-        jobs.insert(2, create_test_job(2, "test"));
-        jobs.insert(3, create_test_job(3, "deploy"));
+        let mut map = HashMap::new();
+        map.insert(job1.id, job1);
+        map.insert(job2.id, job2);
+        map.insert(job3.id, job3);
 
-        let cache = JobCache::new(jobs);
+        let cache = JobCache::new(map);
         let repository = "owner/repo";
 
-        // Save cache
         cache
             .save_with_base(repository, Some(base_dir.clone()))
             .unwrap();
 
-        // Load cache
-        let loaded = JobCache::load_with_base(repository, Some(base_dir));
-        assert!(loaded.is_some());
-
-        let loaded = loaded.unwrap();
+        let loaded = JobCache::load_with_base(repository, Some(base_dir)).unwrap();
         assert_eq!(loaded.jobs.len(), 3);
         assert_eq!(loaded.jobs.get(&1).unwrap().name, "build");
         assert_eq!(loaded.jobs.get(&2).unwrap().name, "test");
@@ -224,33 +204,26 @@ mod tests {
         assert!(loaded.is_none());
     }
 
-    #[test]
-    fn test_cache_clear_existing() {
+    #[fixtura::test]
+    fn test_cache_clear_existing(#[fixtura(id = 1u64, name = "build".to_string())] job: GitHubJob) {
         let temp_dir = TempDir::new().unwrap();
         let base_dir = temp_dir.path().to_path_buf();
 
         let mut jobs = HashMap::new();
-        jobs.insert(1, create_test_job(1, "build"));
+        jobs.insert(job.id, job);
 
         let cache = JobCache::new(jobs);
         let repository = "owner/repo";
 
-        // Save cache
         cache
             .save_with_base(repository, Some(base_dir.clone()))
             .unwrap();
 
-        // Verify it exists
-        let loaded = JobCache::load_with_base(repository, Some(base_dir.clone()));
-        assert!(loaded.is_some());
+        assert!(JobCache::load_with_base(repository, Some(base_dir.clone())).is_some());
 
-        // Clear cache
-        let result = JobCache::clear_with_base(repository, Some(base_dir.clone()));
-        assert!(result.is_ok());
+        JobCache::clear_with_base(repository, Some(base_dir.clone())).unwrap();
 
-        // Verify it's gone
-        let loaded = JobCache::load_with_base(repository, Some(base_dir));
-        assert!(loaded.is_none());
+        assert!(JobCache::load_with_base(repository, Some(base_dir)).is_none());
     }
 
     #[test]
@@ -261,7 +234,6 @@ mod tests {
         let path =
             JobCache::get_cache_file_path_with_base("owner/repo", Some(base_dir.clone())).unwrap();
 
-        // Path should be: <base>/cilens/github/owner-repo.json
         assert!(path.ends_with("cilens/github/owner-repo.json"));
         assert!(path.starts_with(&base_dir));
     }
@@ -271,11 +243,9 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let base_dir = temp_dir.path().to_path_buf();
 
-        let jobs = HashMap::new();
-        let cache = JobCache::new(jobs);
+        let cache = JobCache::new(HashMap::new());
         let repository = "owner/repo";
 
-        // Save and load empty cache
         cache
             .save_with_base(repository, Some(base_dir.clone()))
             .unwrap();

--- a/src/providers/github/jobs.rs
+++ b/src/providers/github/jobs.rs
@@ -218,56 +218,28 @@ fn percentile(sorted: &[f64], p: f64) -> f64 {
 #[allow(clippy::similar_names, clippy::float_cmp)]
 mod tests {
     use super::*;
-    use chrono::{DateTime, TimeZone, Utc};
-
-    fn create_test_job(
-        id: u64,
-        name: &str,
-        conclusion: Option<&str>,
-        run_attempt: u32,
-        duration: f64,
-        workflow_run_started_at: DateTime<Utc>,
-        completed_at: Option<DateTime<Utc>>,
-    ) -> GitHubJob {
-        GitHubJob {
-            id,
-            run_id: 1,
-            name: name.to_string(),
-            workflow_name: "test-workflow".to_string(),
-            status: "completed".to_string(),
-            conclusion: conclusion.map(String::from),
-            run_attempt,
-            duration,
-            started_at: Utc.timestamp_opt(1_609_459_200, 0).unwrap(),
-            completed_at,
-            workflow_run_started_at,
-            html_url: format!("https://github.com/owner/repo/actions/runs/1/jobs/{id}"),
-        }
-    }
+    use chrono::{TimeZone, Utc};
 
     #[test]
     fn test_calculate_job_metrics_empty_jobs() {
-        let jobs = vec![];
-        let metrics = calculate_job_metrics(jobs, 1.0);
+        let metrics = calculate_job_metrics(vec![], 1.0);
         assert_eq!(metrics.len(), 0);
     }
 
-    #[test]
-    fn test_calculate_job_metrics_single_successful_job() {
-        let workflow_start = Utc.timestamp_opt(1_609_459_200, 0).unwrap();
-        let job_complete = Utc.timestamp_opt(1_609_459_260, 0).unwrap();
-
-        let jobs = vec![create_test_job(
-            1,
-            "build",
-            Some("success"),
-            1,
-            60.0,
-            workflow_start,
-            Some(job_complete),
-        )];
-
-        let metrics = calculate_job_metrics(jobs, 1.0);
+    #[fixtura::test]
+    fn test_calculate_job_metrics_single_successful_job(
+        #[fixtura(
+            name = "build".to_string(),
+            conclusion = Some("success".to_string()),
+            run_attempt = 1u32,
+            duration = 60.0_f64,
+            status = "completed".to_string(),
+            workflow_run_started_at = Utc.timestamp_opt(1_609_459_200, 0).unwrap(),
+            completed_at = Some(Utc.timestamp_opt(1_609_459_260, 0).unwrap())
+        )]
+        job: GitHubJob,
+    ) {
+        let metrics = calculate_job_metrics(vec![job], 1.0);
         assert_eq!(metrics.len(), 1);
         assert_eq!(metrics[0].name, "build");
         assert_eq!(metrics[0].duration_p50, 60.0);
@@ -280,200 +252,191 @@ mod tests {
         assert_eq!(metrics[0].total_executions, 1);
     }
 
-    #[test]
-    fn test_calculate_job_metrics_filters_incomplete_jobs() {
-        let workflow_start = Utc.timestamp_opt(1_609_459_200, 0).unwrap();
-
-        let mut jobs = vec![create_test_job(
-            1,
-            "build",
-            Some("success"),
-            1,
-            60.0,
-            workflow_start,
-            Some(Utc.timestamp_opt(1_609_459_260, 0).unwrap()),
-        )];
-
-        // Add an incomplete job (status != "completed")
-        let mut incomplete = jobs[0].clone();
-        incomplete.id = 2;
-        incomplete.status = "in_progress".to_string();
-        jobs.push(incomplete);
-
-        let metrics = calculate_job_metrics(jobs, 1.0);
+    #[fixtura::test]
+    fn test_calculate_job_metrics_filters_incomplete_jobs(
+        #[fixtura(
+            name = "build".to_string(),
+            conclusion = Some("success".to_string()),
+            run_attempt = 1u32,
+            duration = 60.0_f64,
+            status = "completed".to_string(),
+            workflow_run_started_at = Utc.timestamp_opt(1_609_459_200, 0).unwrap(),
+            completed_at = Some(Utc.timestamp_opt(1_609_459_260, 0).unwrap())
+        )]
+        completed: GitHubJob,
+        #[fixtura(name = "build".to_string(), status = "in_progress".to_string())]
+        incomplete: GitHubJob,
+    ) {
+        let metrics = calculate_job_metrics(vec![completed, incomplete], 1.0);
         assert_eq!(metrics.len(), 1);
-        assert_eq!(metrics[0].total_executions, 1); // Only completed job counted
+        assert_eq!(metrics[0].total_executions, 1);
     }
 
-    #[test]
-    fn test_calculate_job_metrics_multiple_executions_same_job() {
-        let workflow_start = Utc.timestamp_opt(1_609_459_200, 0).unwrap();
-
-        let jobs = vec![
-            create_test_job(
-                1,
-                "build",
-                Some("success"),
-                1,
-                50.0,
-                workflow_start,
-                Some(Utc.timestamp_opt(1_609_459_250, 0).unwrap()),
-            ),
-            create_test_job(
-                2,
-                "build",
-                Some("success"),
-                1,
-                100.0,
-                workflow_start,
-                Some(Utc.timestamp_opt(1_609_459_300, 0).unwrap()),
-            ),
-            create_test_job(
-                3,
-                "build",
-                Some("success"),
-                1,
-                150.0,
-                workflow_start,
-                Some(Utc.timestamp_opt(1_609_459_350, 0).unwrap()),
-            ),
-        ];
-
-        let metrics = calculate_job_metrics(jobs, 1.0);
+    #[fixtura::test]
+    fn test_calculate_job_metrics_multiple_executions_same_job(
+        #[fixtura(
+            name = "build".to_string(),
+            conclusion = Some("success".to_string()),
+            run_attempt = 1u32,
+            duration = 50.0_f64,
+            status = "completed".to_string(),
+            workflow_run_started_at = Utc.timestamp_opt(1_609_459_200, 0).unwrap(),
+            completed_at = Some(Utc.timestamp_opt(1_609_459_250, 0).unwrap())
+        )]
+        job1: GitHubJob,
+        #[fixtura(
+            name = "build".to_string(),
+            conclusion = Some("success".to_string()),
+            run_attempt = 1u32,
+            duration = 100.0_f64,
+            status = "completed".to_string(),
+            workflow_run_started_at = Utc.timestamp_opt(1_609_459_200, 0).unwrap(),
+            completed_at = Some(Utc.timestamp_opt(1_609_459_300, 0).unwrap())
+        )]
+        job2: GitHubJob,
+        #[fixtura(
+            name = "build".to_string(),
+            conclusion = Some("success".to_string()),
+            run_attempt = 1u32,
+            duration = 150.0_f64,
+            status = "completed".to_string(),
+            workflow_run_started_at = Utc.timestamp_opt(1_609_459_200, 0).unwrap(),
+            completed_at = Some(Utc.timestamp_opt(1_609_459_350, 0).unwrap())
+        )]
+        job3: GitHubJob,
+    ) {
+        let metrics = calculate_job_metrics(vec![job1, job2, job3], 1.0);
         assert_eq!(metrics.len(), 1);
         assert_eq!(metrics[0].name, "build");
         assert_eq!(metrics[0].total_executions, 3);
-        assert_eq!(metrics[0].duration_p50, 100.0); // Middle value
+        assert_eq!(metrics[0].duration_p50, 100.0);
     }
 
-    #[test]
-    fn test_calculate_job_metrics_retry_detection() {
-        let workflow_start = Utc.timestamp_opt(1_609_459_200, 0).unwrap();
-
-        let jobs = vec![
-            create_test_job(
-                1,
-                "build",
-                Some("success"),
-                1,
-                60.0,
-                workflow_start,
-                Some(Utc.timestamp_opt(1_609_459_260, 0).unwrap()),
-            ),
-            create_test_job(
-                2,
-                "build",
-                Some("success"),
-                2,
-                60.0,
-                workflow_start,
-                Some(Utc.timestamp_opt(1_609_459_260, 0).unwrap()),
-            ), // Retry
-            create_test_job(
-                3,
-                "build",
-                Some("success"),
-                3,
-                60.0,
-                workflow_start,
-                Some(Utc.timestamp_opt(1_609_459_260, 0).unwrap()),
-            ), // Another retry
-        ];
-
-        let metrics = calculate_job_metrics(jobs, 1.0);
+    #[fixtura::test]
+    fn test_calculate_job_metrics_retry_detection(
+        #[fixtura(
+            name = "build".to_string(),
+            conclusion = Some("success".to_string()),
+            run_attempt = 1u32,
+            duration = 60.0_f64,
+            status = "completed".to_string(),
+            workflow_run_started_at = Utc.timestamp_opt(1_609_459_200, 0).unwrap(),
+            completed_at = Some(Utc.timestamp_opt(1_609_459_260, 0).unwrap())
+        )]
+        job1: GitHubJob,
+        #[fixtura(
+            name = "build".to_string(),
+            conclusion = Some("success".to_string()),
+            run_attempt = 2u32,
+            duration = 60.0_f64,
+            status = "completed".to_string(),
+            workflow_run_started_at = Utc.timestamp_opt(1_609_459_200, 0).unwrap(),
+            completed_at = Some(Utc.timestamp_opt(1_609_459_260, 0).unwrap())
+        )]
+        job2: GitHubJob,
+        #[fixtura(
+            name = "build".to_string(),
+            conclusion = Some("success".to_string()),
+            run_attempt = 3u32,
+            duration = 60.0_f64,
+            status = "completed".to_string(),
+            workflow_run_started_at = Utc.timestamp_opt(1_609_459_200, 0).unwrap(),
+            completed_at = Some(Utc.timestamp_opt(1_609_459_260, 0).unwrap())
+        )]
+        job3: GitHubJob,
+    ) {
+        let metrics = calculate_job_metrics(vec![job1, job2, job3], 1.0);
         assert_eq!(metrics.len(), 1);
-        assert_eq!(metrics[0].retry_rate, 66.666_666_666_666_66); // 2 out of 3
+        assert_eq!(metrics[0].retry_rate, 66.666_666_666_666_66);
         assert_eq!(metrics[0].retried_executions.count, 2);
     }
 
-    #[test]
-    fn test_calculate_job_metrics_failure_rate() {
-        let workflow_start = Utc.timestamp_opt(1_609_459_200, 0).unwrap();
-
-        let jobs = vec![
-            create_test_job(
-                1,
-                "test",
-                Some("success"),
-                1,
-                60.0,
-                workflow_start,
-                Some(Utc.timestamp_opt(1_609_459_260, 0).unwrap()),
-            ),
-            create_test_job(
-                2,
-                "test",
-                Some("failure"),
-                1,
-                30.0,
-                workflow_start,
-                Some(Utc.timestamp_opt(1_609_459_230, 0).unwrap()),
-            ),
-            create_test_job(
-                3,
-                "test",
-                Some("failure"),
-                1,
-                40.0,
-                workflow_start,
-                Some(Utc.timestamp_opt(1_609_459_240, 0).unwrap()),
-            ),
-            create_test_job(
-                4,
-                "test",
-                Some("success"),
-                1,
-                70.0,
-                workflow_start,
-                Some(Utc.timestamp_opt(1_609_459_270, 0).unwrap()),
-            ),
-        ];
-
-        let metrics = calculate_job_metrics(jobs, 1.0);
+    #[fixtura::test]
+    fn test_calculate_job_metrics_failure_rate(
+        #[fixtura(
+            name = "test".to_string(),
+            conclusion = Some("success".to_string()),
+            run_attempt = 1u32,
+            duration = 60.0_f64,
+            status = "completed".to_string(),
+            workflow_run_started_at = Utc.timestamp_opt(1_609_459_200, 0).unwrap(),
+            completed_at = Some(Utc.timestamp_opt(1_609_459_260, 0).unwrap())
+        )]
+        job1: GitHubJob,
+        #[fixtura(
+            name = "test".to_string(),
+            conclusion = Some("failure".to_string()),
+            run_attempt = 1u32,
+            duration = 30.0_f64,
+            status = "completed".to_string(),
+            workflow_run_started_at = Utc.timestamp_opt(1_609_459_200, 0).unwrap(),
+            completed_at = Some(Utc.timestamp_opt(1_609_459_230, 0).unwrap())
+        )]
+        job2: GitHubJob,
+        #[fixtura(
+            name = "test".to_string(),
+            conclusion = Some("failure".to_string()),
+            run_attempt = 1u32,
+            duration = 40.0_f64,
+            status = "completed".to_string(),
+            workflow_run_started_at = Utc.timestamp_opt(1_609_459_200, 0).unwrap(),
+            completed_at = Some(Utc.timestamp_opt(1_609_459_240, 0).unwrap())
+        )]
+        job3: GitHubJob,
+        #[fixtura(
+            name = "test".to_string(),
+            conclusion = Some("success".to_string()),
+            run_attempt = 1u32,
+            duration = 70.0_f64,
+            status = "completed".to_string(),
+            workflow_run_started_at = Utc.timestamp_opt(1_609_459_200, 0).unwrap(),
+            completed_at = Some(Utc.timestamp_opt(1_609_459_270, 0).unwrap())
+        )]
+        job4: GitHubJob,
+    ) {
+        let metrics = calculate_job_metrics(vec![job1, job2, job3, job4], 1.0);
         assert_eq!(metrics.len(), 1);
-        assert_eq!(metrics[0].failure_rate, 50.0); // 2 out of 4
+        assert_eq!(metrics[0].failure_rate, 50.0);
         assert_eq!(metrics[0].failed_executions.count, 2);
-        assert_eq!(metrics[0].success_rate, 50.0); // 2 out of 4
+        assert_eq!(metrics[0].success_rate, 50.0);
         assert_eq!(metrics[0].successful_executions.count, 2);
     }
 
-    #[test]
-    fn test_calculate_job_metrics_sorts_by_time_to_feedback() {
-        let workflow_start = Utc.timestamp_opt(1_609_459_200, 0).unwrap();
-
-        let jobs = vec![
-            create_test_job(
-                1,
-                "fast",
-                Some("success"),
-                1,
-                30.0,
-                workflow_start,
-                Some(Utc.timestamp_opt(1_609_459_230, 0).unwrap()),
-            ), // TTF = 30s
-            create_test_job(
-                2,
-                "slow",
-                Some("success"),
-                1,
-                300.0,
-                workflow_start,
-                Some(Utc.timestamp_opt(1_609_459_500, 0).unwrap()),
-            ), // TTF = 300s
-            create_test_job(
-                3,
-                "medium",
-                Some("success"),
-                1,
-                120.0,
-                workflow_start,
-                Some(Utc.timestamp_opt(1_609_459_320, 0).unwrap()),
-            ), // TTF = 120s
-        ];
-
-        let metrics = calculate_job_metrics(jobs, 1.0);
+    #[fixtura::test]
+    fn test_calculate_job_metrics_sorts_by_time_to_feedback(
+        #[fixtura(
+            name = "fast".to_string(),
+            conclusion = Some("success".to_string()),
+            run_attempt = 1u32,
+            duration = 30.0_f64,
+            status = "completed".to_string(),
+            workflow_run_started_at = Utc.timestamp_opt(1_609_459_200, 0).unwrap(),
+            completed_at = Some(Utc.timestamp_opt(1_609_459_230, 0).unwrap())
+        )]
+        fast: GitHubJob,
+        #[fixtura(
+            name = "slow".to_string(),
+            conclusion = Some("success".to_string()),
+            run_attempt = 1u32,
+            duration = 300.0_f64,
+            status = "completed".to_string(),
+            workflow_run_started_at = Utc.timestamp_opt(1_609_459_200, 0).unwrap(),
+            completed_at = Some(Utc.timestamp_opt(1_609_459_500, 0).unwrap())
+        )]
+        slow: GitHubJob,
+        #[fixtura(
+            name = "medium".to_string(),
+            conclusion = Some("success".to_string()),
+            run_attempt = 1u32,
+            duration = 120.0_f64,
+            status = "completed".to_string(),
+            workflow_run_started_at = Utc.timestamp_opt(1_609_459_200, 0).unwrap(),
+            completed_at = Some(Utc.timestamp_opt(1_609_459_320, 0).unwrap())
+        )]
+        medium: GitHubJob,
+    ) {
+        let metrics = calculate_job_metrics(vec![fast, slow, medium], 1.0);
         assert_eq!(metrics.len(), 3);
-        // Should be sorted by time_to_feedback descending (slowest first)
         assert_eq!(metrics[0].name, "slow");
         assert_eq!(metrics[0].time_to_feedback_p50, 300.0);
         assert_eq!(metrics[1].name, "medium");

--- a/src/providers/github/provider.rs
+++ b/src/providers/github/provider.rs
@@ -54,7 +54,7 @@ impl GitHubProvider {
         limit: usize,
     ) -> Vec<GitHubJob> {
         let mut jobs: Vec<GitHubJob> = map.into_values().collect();
-        jobs.sort_by(|a, b| b.started_at.cmp(&a.started_at));
+        jobs.sort_by_key(|b| std::cmp::Reverse(b.started_at));
         jobs.into_iter().take(limit).collect()
     }
 
@@ -484,15 +484,14 @@ mod tests {
         assert_eq!(github_job.completed_at, None);
     }
 
-    #[test]
-    fn test_jobs_to_map() {
-        let jobs = vec![
-            create_github_job(1, "build"),
-            create_github_job(2, "test"),
-            create_github_job(3, "deploy"),
-        ];
-
-        let map = GitHubProvider::jobs_to_map(&jobs);
+    #[fixtura::test]
+    fn test_jobs_to_map(
+        #[fixtura(id = 1u64, name = "build".to_string())] job1: GitHubJob,
+        #[fixtura(id = 2u64, name = "test".to_string())] job2: GitHubJob,
+        #[fixtura(id = 3u64, name = "deploy".to_string())] job3: GitHubJob,
+    ) {
+        let all = vec![job1, job2, job3];
+        let map = GitHubProvider::jobs_to_map(&all);
 
         assert_eq!(map.len(), 3);
         assert_eq!(map.get(&1).unwrap().name, "build");
@@ -500,91 +499,46 @@ mod tests {
         assert_eq!(map.get(&3).unwrap().name, "deploy");
     }
 
-    #[test]
-    fn test_map_to_sorted_jobs() {
+    #[fixtura::test]
+    fn test_map_to_sorted_jobs(
+        #[fixtura(id = 1u64, name = "job1".to_string(), started_at = Utc.timestamp_opt(1_609_459_210, 0).unwrap())]
+        job1: GitHubJob,
+        #[fixtura(id = 2u64, name = "job2".to_string(), started_at = Utc.timestamp_opt(1_609_459_230, 0).unwrap())]
+        job2: GitHubJob,
+        #[fixtura(id = 3u64, name = "job3".to_string(), started_at = Utc.timestamp_opt(1_609_459_220, 0).unwrap())]
+        job3: GitHubJob,
+    ) {
         let mut map = HashMap::new();
-        map.insert(
-            1,
-            create_github_job_with_time(1, "job1", Utc.timestamp_opt(1_609_459_210, 0).unwrap()),
-        );
-        map.insert(
-            2,
-            create_github_job_with_time(2, "job2", Utc.timestamp_opt(1_609_459_230, 0).unwrap()),
-        );
-        map.insert(
-            3,
-            create_github_job_with_time(3, "job3", Utc.timestamp_opt(1_609_459_220, 0).unwrap()),
-        );
+        map.insert(job1.id, job1);
+        map.insert(job2.id, job2);
+        map.insert(job3.id, job3);
 
-        let jobs = GitHubProvider::map_to_sorted_jobs(map, 10);
+        let sorted = GitHubProvider::map_to_sorted_jobs(map, 10);
 
-        assert_eq!(jobs.len(), 3);
-        // Should be sorted by started_at descending (newest first)
-        assert_eq!(jobs[0].name, "job2"); // 230
-        assert_eq!(jobs[1].name, "job3"); // 220
-        assert_eq!(jobs[2].name, "job1"); // 210
+        assert_eq!(sorted.len(), 3);
+        assert_eq!(sorted[0].name, "job2"); // 230 — newest
+        assert_eq!(sorted[1].name, "job3"); // 220
+        assert_eq!(sorted[2].name, "job1"); // 210 — oldest
     }
 
-    #[test]
-    fn test_map_to_sorted_jobs_respects_limit() {
+    #[fixtura::test]
+    fn test_map_to_sorted_jobs_respects_limit(
+        #[fixtura(id = 1u64, name = "job1".to_string(), started_at = Utc.timestamp_opt(1_609_459_210, 0).unwrap())]
+        job1: GitHubJob,
+        #[fixtura(id = 2u64, name = "job2".to_string(), started_at = Utc.timestamp_opt(1_609_459_230, 0).unwrap())]
+        job2: GitHubJob,
+        #[fixtura(id = 3u64, name = "job3".to_string(), started_at = Utc.timestamp_opt(1_609_459_220, 0).unwrap())]
+        job3: GitHubJob,
+    ) {
         let mut map = HashMap::new();
-        map.insert(
-            1,
-            create_github_job_with_time(1, "job1", Utc.timestamp_opt(1_609_459_210, 0).unwrap()),
-        );
-        map.insert(
-            2,
-            create_github_job_with_time(2, "job2", Utc.timestamp_opt(1_609_459_230, 0).unwrap()),
-        );
-        map.insert(
-            3,
-            create_github_job_with_time(3, "job3", Utc.timestamp_opt(1_609_459_220, 0).unwrap()),
-        );
+        map.insert(job1.id, job1);
+        map.insert(job2.id, job2);
+        map.insert(job3.id, job3);
 
-        let jobs = GitHubProvider::map_to_sorted_jobs(map, 2);
+        let sorted = GitHubProvider::map_to_sorted_jobs(map, 2);
 
-        assert_eq!(jobs.len(), 2);
-        // Should be the 2 newest jobs
-        assert_eq!(jobs[0].name, "job2");
-        assert_eq!(jobs[1].name, "job3");
-    }
-
-    // Helper functions
-    fn create_github_job(id: u64, name: &str) -> GitHubJob {
-        GitHubJob {
-            id,
-            run_id: 1,
-            name: name.to_string(),
-            workflow_name: "test-workflow".to_string(),
-            status: "completed".to_string(),
-            conclusion: Some("success".to_string()),
-            run_attempt: 1,
-            duration: 60.0,
-            started_at: Utc.timestamp_opt(1_609_459_200, 0).unwrap(),
-            completed_at: Some(Utc.timestamp_opt(1_609_459_260, 0).unwrap()),
-            workflow_run_started_at: Utc.timestamp_opt(1_609_459_200, 0).unwrap(),
-            html_url: format!("https://github.com/owner/repo/actions/runs/1/jobs/{id}"),
-        }
-    }
-
-    fn create_github_job_with_time(
-        id: u64,
-        name: &str,
-        started_at: chrono::DateTime<Utc>,
-    ) -> GitHubJob {
-        GitHubJob {
-            id,
-            run_id: 1,
-            name: name.to_string(),
-            workflow_name: "test-workflow".to_string(),
-            status: "completed".to_string(),
-            conclusion: Some("success".to_string()),
-            run_attempt: 1,
-            duration: 60.0,
-            started_at,
-            completed_at: Some(started_at + chrono::Duration::seconds(60)),
-            workflow_run_started_at: started_at,
-            html_url: format!("https://github.com/owner/repo/actions/runs/1/jobs/{id}"),
-        }
+        assert_eq!(sorted.len(), 2);
+        assert_eq!(sorted[0].name, "job2"); // newest
+        assert_eq!(sorted[1].name, "job3");
     }
 }

--- a/src/providers/github/types.rs
+++ b/src/providers/github/types.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// Represents a single job execution with its workflow context and execution details.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(test, derive(fake::Dummy))]
 pub struct GitHubJob {
     /// GitHub job ID
     pub id: u64,

--- a/src/providers/gitlab/cache.rs
+++ b/src/providers/gitlab/cache.rs
@@ -155,45 +155,30 @@ impl JobCache {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::Utc;
     use tempfile::TempDir;
 
-    fn create_test_job(id: &str, name: &str) -> GitLabJob {
-        GitLabJob {
-            id: id.to_string(),
-            name: name.to_string(),
-            duration: 10.0,
-            status: "SUCCESS".to_string(),
-            retried: false,
-            needs: vec![],
-            created_at: Utc::now(),
-            finished_at: Utc::now(),
-        }
-    }
-
-    #[test]
-    fn test_cache_save_and_load_roundtrip() {
+    #[fixtura::test]
+    fn test_cache_save_and_load_roundtrip(
+        #[fixtura(id = "1".to_string(), name = "build".to_string())] job1: GitLabJob,
+        #[fixtura(id = "2".to_string(), name = "test".to_string())] job2: GitLabJob,
+        #[fixtura(id = "3".to_string(), name = "deploy".to_string())] job3: GitLabJob,
+    ) {
         let temp_dir = TempDir::new().unwrap();
         let base_dir = temp_dir.path().to_path_buf();
 
-        let mut jobs = HashMap::new();
-        jobs.insert("1".to_string(), create_test_job("1", "build"));
-        jobs.insert("2".to_string(), create_test_job("2", "test"));
-        jobs.insert("3".to_string(), create_test_job("3", "deploy"));
+        let mut map = HashMap::new();
+        map.insert(job1.id.clone(), job1);
+        map.insert(job2.id.clone(), job2);
+        map.insert(job3.id.clone(), job3);
 
-        let cache = JobCache::new(jobs);
+        let cache = JobCache::new(map);
         let project_path = "group/project";
 
-        // Save cache
         cache
             .save_with_base(project_path, Some(base_dir.clone()))
             .unwrap();
 
-        // Load cache
-        let loaded = JobCache::load_with_base(project_path, Some(base_dir));
-        assert!(loaded.is_some());
-
-        let loaded = loaded.unwrap();
+        let loaded = JobCache::load_with_base(project_path, Some(base_dir)).unwrap();
         assert_eq!(loaded.jobs.len(), 3);
         assert_eq!(loaded.jobs.get("1").unwrap().name, "build");
         assert_eq!(loaded.jobs.get("2").unwrap().name, "test");
@@ -209,53 +194,47 @@ mod tests {
         assert!(loaded.is_none());
     }
 
-    #[test]
-    fn test_cache_clear() {
+    #[fixtura::test]
+    fn test_cache_clear(job: GitLabJob) {
         let temp_dir = TempDir::new().unwrap();
         let base_dir = temp_dir.path().to_path_buf();
 
-        let mut jobs = HashMap::new();
-        jobs.insert("1".to_string(), create_test_job("1", "test"));
-        let cache = JobCache::new(jobs);
+        let mut map = HashMap::new();
+        map.insert(job.id.clone(), job);
+        let cache = JobCache::new(map);
         let project_path = "group/project";
 
-        // Save cache
         cache
             .save_with_base(project_path, Some(base_dir.clone()))
             .unwrap();
 
-        // Verify it exists
-        let loaded = JobCache::load_with_base(project_path, Some(base_dir.clone()));
-        assert!(loaded.is_some());
+        assert!(JobCache::load_with_base(project_path, Some(base_dir.clone())).is_some());
 
-        // Clear cache
         JobCache::clear_with_base(project_path, Some(base_dir.clone())).unwrap();
 
-        // Verify it's gone
-        let loaded = JobCache::load_with_base(project_path, Some(base_dir));
-        assert!(loaded.is_none());
+        assert!(JobCache::load_with_base(project_path, Some(base_dir)).is_none());
     }
 
-    #[test]
-    fn test_per_project_cache_files() {
+    #[fixtura::test]
+    fn test_per_project_cache_files(
+        #[fixtura(id = "1".to_string(), name = "test1".to_string())] job1: GitLabJob,
+        #[fixtura(id = "2".to_string(), name = "test2".to_string())] job2: GitLabJob,
+    ) {
         let temp_dir = TempDir::new().unwrap();
         let base_dir = temp_dir.path().to_path_buf();
 
-        let mut jobs1 = HashMap::new();
-        jobs1.insert("1".to_string(), create_test_job("1", "test1"));
-        let cache1 = JobCache::new(jobs1);
-        cache1
+        let mut map1 = HashMap::new();
+        map1.insert(job1.id.clone(), job1);
+        JobCache::new(map1)
             .save_with_base("group/project1", Some(base_dir.clone()))
             .unwrap();
 
-        let mut jobs2 = HashMap::new();
-        jobs2.insert("2".to_string(), create_test_job("2", "test2"));
-        let cache2 = JobCache::new(jobs2);
-        cache2
+        let mut map2 = HashMap::new();
+        map2.insert(job2.id.clone(), job2);
+        JobCache::new(map2)
             .save_with_base("group/project2", Some(base_dir.clone()))
             .unwrap();
 
-        // Verify both caches exist and contain correct data
         let loaded1 = JobCache::load_with_base("group/project1", Some(base_dir.clone())).unwrap();
         assert_eq!(loaded1.jobs.len(), 1);
         assert_eq!(loaded1.jobs.get("1").unwrap().name, "test1");

--- a/src/providers/gitlab/jobs.rs
+++ b/src/providers/gitlab/jobs.rs
@@ -354,30 +354,14 @@ mod tests {
 
     mod aggregate_jobs_by_name {
         use super::*;
-        use chrono::Utc;
 
-        fn create_test_job(name: &str, id: &str) -> GitLabJob {
-            GitLabJob {
-                id: id.to_string(),
-                name: name.to_string(),
-                duration: 100.0,
-                status: "SUCCESS".to_string(),
-                retried: false,
-                needs: vec![],
-                created_at: Utc::now(),
-                finished_at: Utc::now(),
-            }
-        }
-
-        #[test]
-        fn aggregates_jobs_by_name() {
-            let jobs = vec![
-                create_test_job("build", "1"),
-                create_test_job("test", "2"),
-                create_test_job("build", "3"),
-            ];
-
-            let result = aggregate_jobs_by_name(jobs);
+        #[fixtura::test]
+        fn aggregates_jobs_by_name(
+            #[fixtura(name = "build".to_string())] job1: GitLabJob,
+            #[fixtura(name = "test".to_string())] job2: GitLabJob,
+            #[fixtura(name = "build".to_string())] job3: GitLabJob,
+        ) {
+            let result = aggregate_jobs_by_name(vec![job1, job2, job3]);
             assert_eq!(result.len(), 2);
             assert_eq!(result.get("build").unwrap().len(), 2);
             assert_eq!(result.get("test").unwrap().len(), 1);
@@ -385,15 +369,13 @@ mod tests {
 
         #[test]
         fn handles_empty_list() {
-            let jobs = vec![];
-            let result = aggregate_jobs_by_name(jobs);
+            let result = aggregate_jobs_by_name(vec![]);
             assert_eq!(result.len(), 0);
         }
 
-        #[test]
-        fn handles_single_job() {
-            let jobs = vec![create_test_job("deploy", "1")];
-            let result = aggregate_jobs_by_name(jobs);
+        #[fixtura::test]
+        fn handles_single_job(#[fixtura(name = "deploy".to_string())] job: GitLabJob) {
+            let result = aggregate_jobs_by_name(vec![job]);
             assert_eq!(result.len(), 1);
             assert_eq!(result.get("deploy").unwrap().len(), 1);
         }
@@ -446,62 +428,43 @@ mod tests {
 
     mod extract_predecessors {
         use super::*;
-        use chrono::Utc;
 
-        fn create_job_with_needs(name: &str, needs: Vec<String>) -> GitLabJob {
-            GitLabJob {
-                id: name.to_string(),
-                name: name.to_string(),
-                duration: 100.0,
-                status: "SUCCESS".to_string(),
-                retried: false,
-                needs,
-                created_at: Utc::now(),
-                finished_at: Utc::now(),
-            }
-        }
-
-        #[test]
-        fn extracts_unique_predecessors() {
-            let executions = vec![
-                create_job_with_needs("test", vec!["build".to_string(), "lint".to_string()]),
-                create_job_with_needs("test", vec!["build".to_string()]),
-            ];
-
+        #[fixtura::test]
+        fn extracts_unique_predecessors(
+            #[fixtura(needs = vec!["build".to_string(), "lint".to_string()])] job1: GitLabJob,
+            #[fixtura(needs = vec!["build".to_string()])] job2: GitLabJob,
+        ) {
+            let executions = vec![job1, job2];
             let result = extract_predecessors(&executions);
             assert_eq!(result.len(), 2);
             assert!(result.contains(&"build".to_string()));
             assert!(result.contains(&"lint".to_string()));
         }
 
-        #[test]
-        fn handles_no_predecessors() {
-            let executions = vec![create_job_with_needs("test", vec![])];
-            let result = extract_predecessors(&executions);
+        #[fixtura::test]
+        fn handles_no_predecessors(#[fixtura(needs = vec![])] job: GitLabJob) {
+            let result = extract_predecessors(&[job]);
             assert_eq!(result.len(), 0);
         }
 
-        #[test]
-        fn deduplicates_predecessors() {
-            let executions = vec![
-                create_job_with_needs("test", vec!["build".to_string()]),
-                create_job_with_needs("test", vec!["build".to_string()]),
-                create_job_with_needs("test", vec!["build".to_string()]),
-            ];
-
+        #[fixtura::test]
+        fn deduplicates_predecessors(
+            #[fixtura(needs = vec!["build".to_string()])] job1: GitLabJob,
+            #[fixtura(needs = vec!["build".to_string()])] job2: GitLabJob,
+            #[fixtura(needs = vec!["build".to_string()])] job3: GitLabJob,
+        ) {
+            let executions = vec![job1, job2, job3];
             let result = extract_predecessors(&executions);
             assert_eq!(result.len(), 1);
             assert_eq!(result[0], "build");
         }
 
-        #[test]
-        fn returns_sorted_predecessors() {
-            let executions = vec![create_job_with_needs(
-                "test",
-                vec!["zyx".to_string(), "abc".to_string(), "mno".to_string()],
-            )];
-
-            let result = extract_predecessors(&executions);
+        #[fixtura::test]
+        fn returns_sorted_predecessors(
+            #[fixtura(needs = vec!["zyx".to_string(), "abc".to_string(), "mno".to_string()])]
+            job: GitLabJob,
+        ) {
+            let result = extract_predecessors(&[job]);
             assert_eq!(result, vec!["abc", "mno", "zyx"]);
         }
     }

--- a/src/providers/gitlab/provider.rs
+++ b/src/providers/gitlab/provider.rs
@@ -97,7 +97,7 @@ impl GitLabProvider {
         limit: usize,
     ) -> Vec<GitLabJob> {
         let mut jobs: Vec<GitLabJob> = map.into_values().collect();
-        jobs.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        jobs.sort_by_key(|b| std::cmp::Reverse(b.created_at));
         jobs.into_iter().take(limit).collect()
     }
 

--- a/src/providers/gitlab/types.rs
+++ b/src/providers/gitlab/types.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// Represents a single job execution with its dependencies and execution details.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(test, derive(fake::Dummy))]
 pub struct GitLabJob {
     /// GraphQL Global ID (e.g., <gid://gitlab/Ci::Job/456>)
     pub id: String,


### PR DESCRIPTION
## Summary

- Replace manual `create_test_job()` / `create_job_with_needs()` helpers with `#[fixtura::test]` and field override attributes across `github/cache.rs`, `github/jobs.rs`, and `gitlab/jobs.rs`
- Add `#[cfg_attr(test, derive(fake::Dummy))]` to `GitHubJob` and `GitLabJob` so `fake` remains a dev-dependency only (no production binary impact)
- Add `.DS_Store` to `.gitignore`

## Test plan

- [x] All 170 tests pass (`cargo test`)
- [x] Verify fixtura field overrides pin the values each test depends on (IDs, names, timestamps, conclusions)
- [x] Confirm pure-math tests (`calculate_rate`, `calculate_percentiles`) and serialization tests remain as plain `#[test]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)